### PR TITLE
ci: changed to $GITHUB_OUTPUT from set-output

### DIFF
--- a/.github/workflows/fetch-tomachi-emojis.yml
+++ b/.github/workflows/fetch-tomachi-emojis.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       working-directory: ./.github/scripts/fetch-tomachi-emojis/
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache node_modules
       uses: actions/cache@v3.0.11
@@ -48,7 +48,7 @@ jobs:
     - name: Get yarn cache directory path (Generate README)
       id: yarn-cache-dir-path-gen-readme
       working-directory: ./.github/scripts/generate-readme/
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache node_modules (Generate README)
       uses: actions/cache@v3.0.11

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       working-directory: ./.github/scripts/generate-readme/
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache node_modules
       uses: actions/cache@v3.0.11

--- a/.github/workflows/nodejs-multi-ci.yml
+++ b/.github/workflows/nodejs-multi-ci.yml
@@ -49,16 +49,16 @@ jobs:
           echo "lint: $lint"
           echo "test: $test"
 
-          echo "::set-output name=compile::$compile"
-          echo "::set-output name=build::$build"
-          echo "::set-output name=generate::$generate"
-          echo "::set-output name=package::$package"
-          echo "::set-output name=lint::$lint"
-          echo "::set-output name=test::$test"
+          echo "compile=$compile" >> $GITHUB_OUTPUT
+          echo "build=$build" >> $GITHUB_OUTPUT
+          echo "generate=$generate" >> $GITHUB_OUTPUT
+          echo "package=$package" >> $GITHUB_OUTPUT
+          echo "lint=$lint" >> $GITHUB_OUTPUT
+          echo "test=$test" >> $GITHUB_OUTPUT
 
       - name: 🛠 Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: 📦 Cache node_modules
         uses: actions/cache@v3


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/