### PR TITLE
fix: 直接プッシュの代わりにプルリクエスト経由で絵文字を更新する

### DIFF
--- a/.github/workflows/fetch-tomachi-emojis.yml
+++ b/.github/workflows/fetch-tomachi-emojis.yml
@@ -8,12 +8,14 @@ on:
 jobs:
   fetch-emojis:
    runs-on: ubuntu-latest
+   permissions:
+     contents: write
+     pull-requests: write
 
    steps:
     - name: Checkout repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
-        persist-credentials: false
         fetch-depth: 0
 
     - name: Setup node
@@ -77,12 +79,19 @@ jobs:
       working-directory: ./.github/scripts/generate-readme/
       run: pnpm start --target-emojis ../../../icons/ --target-stickers ../../../stickers/ --output ../../../README.md --target-guilds ../../../targetGuilds.json --emojis ../../../emojis.json --stickers ../../../stickers.json
 
-    - name: Commit & Push
-      run: |
-        git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
-        git config --global user.name "GitHub Action"
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add -A && git commit -v -m "feat: Fetched emojis from Tomachi Emojis" || true
-        git push origin master
+    - name: Create Pull Request
+      id: create-pr
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "feat: Fetched emojis from Tomachi Emojis"
+        branch: automated/fetch-tomachi-emojis
+        title: "feat: Fetch emojis from Tomachi Emojis"
+        body: "絵文字フェッチワークフローによる自動更新"
+        delete-branch: true
+
+    - name: Enable auto-merge
+      if: steps.create-pr.outputs.pull-request-number != ''
+      run: gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-url }}"
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

ブランチ保護ルールセット（ID: 12129660）により `master` への直接プッシュが禁止されているため、ワークフローが失敗していた問題を修正します。

## 変更内容

### `fetch-tomachi-emojis.yml`

- **削除**: `git push origin master` による直接プッシュステップ
- **追加**: `peter-evans/create-pull-request@v7` による PR 作成ステップ
  - ブランチ名: `automated/fetch-tomachi-emojis`
  - 変更がない場合は PR を作成しない（冗長実行を防止）
  - 同ブランチが既に存在する場合は PR を更新する
- **追加**: `gh pr merge --auto --squash` による auto-merge 有効化ステップ
  - `allow_auto_merge: true` かつ `required_approving_review_count: 0` のため、CI 通過後に自動マージされる
- **変更**: `persist-credentials: false` を削除（`peter-evans/create-pull-request` が認証情報を内部処理するため不要）
- **追加**: `permissions: contents: write, pull-requests: write`（PR 作成に必要な権限）

## 動作フロー（修正後）

1. ワークフローが毎時実行される
2. 絵文字を取得し README を生成する
3. 変更がある場合、`automated/fetch-tomachi-emojis` ブランチに PR を作成する
4. `Check finished Node CI` CI が自動実行・通過する
5. auto-merge により squash マージされ `master` に取り込まれる

## 判断記録

| 項目 | 内容 |
|---|---|
| 判断内容 | 直接プッシュを廃止し PR + auto-merge 方式に変更 |
| 検討した代替案 | (1) ルールセットにバイパスアクターを追加、(2) Personal Access Token 使用 |
| 採用しなかった案の理由 | (1) tomacheese org の管理者権限がないため API 経由では設定不可（PATCH → 404）、(2) PAT 管理のオーバーヘッドが生じる |
| 前提・仮定 | `required_approving_review_count: 0` かつ `allow_auto_merge: true` のため人手不要で自動完結できる |