### PR TITLE
fix: PR 経由ではなく deploy key SSH で直接 master へプッシュする

### DIFF
--- a/.github/workflows/fetch-tomachi-emojis.yml
+++ b/.github/workflows/fetch-tomachi-emojis.yml
@@ -9,13 +9,13 @@ jobs:
   fetch-emojis:
    runs-on: ubuntu-latest
    permissions:
-     contents: write
-     pull-requests: write
+     contents: read
 
    steps:
     - name: Checkout repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Setup node
@@ -79,19 +79,46 @@ jobs:
       working-directory: ./.github/scripts/generate-readme/
       run: pnpm start --target-emojis ../../../icons/ --target-stickers ../../../stickers/ --output ../../../README.md --target-guilds ../../../targetGuilds.json --emojis ../../../emojis.json --stickers ../../../stickers.json
 
-    - name: Create Pull Request
-      id: create-pr
-      uses: peter-evans/create-pull-request@v8
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "feat: Fetched emojis from Tomachi Emojis"
-        branch: automated/fetch-tomachi-emojis
-        title: "feat: Fetch emojis from Tomachi Emojis"
-        body: "絵文字フェッチワークフローによる自動更新"
-        delete-branch: true
-
-    - name: Enable auto-merge
-      if: steps.create-pr.outputs.pull-request-number != ''
-      run: gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-url }}"
+    - name: Setup SSH for push
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PUSH_DEPLOY_KEY: ${{ secrets.PUSH_DEPLOY_KEY }}
+      run: |
+        mkdir -p ~/.ssh
+
+        # 秘密鍵を書き込む
+        echo "$PUSH_DEPLOY_KEY" > ~/.ssh/deploy_ed25519
+        chmod 600 ~/.ssh/deploy_ed25519
+
+        # GitHub の公式 SSH ホスト鍵を固定値で書き込む（ssh-keyscan による MITM リスクを回避）
+        cat > ~/.ssh/known_hosts << 'KNOWNHOSTS'
+        github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+        github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+        github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+        KNOWNHOSTS
+
+        # SSH config を設定
+        cat > ~/.ssh/config << 'SSHCONFIG'
+        Host github.com
+          IdentityFile ~/.ssh/deploy_ed25519
+          StrictHostKeyChecking yes
+          UserKnownHostsFile ~/.ssh/known_hosts
+          BatchMode yes
+        SSHCONFIG
+
+        # SSH 接続テストで Deploy Key 認証を事前確認（exit 1 は GitHub の正常動作）
+        ssh_output=$(ssh -T git@github.com 2>&1 || true)
+        echo "$ssh_output"
+        if [[ "$ssh_output" != *"successfully authenticated"* ]]; then
+          echo "SSH authentication failed"
+          exit 1
+        fi
+
+        # Deploy Key で Ruleset をバイパスするため SSH URL に変更
+        git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
+
+    - name: Commit & Push
+      run: |
+        git config --global user.name "GitHub Action"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A && git commit -v -m "feat: Fetched emojis from Tomachi Emojis" || true
+        git push origin master


### PR DESCRIPTION
## 概要

PR + auto-merge 方式 (#1580) から、deploy key を使った SSH 直接プッシュへ変更します。

## 背景

GitHub の仕様により、**write 権限を持つ deploy key は repository ruleset をデフォルトでバイパス**します。`bypass_actors` への追加は不要です。`book000/scoop-bucket` が同一パターンを使用していることを確認済みです（`bypass_actors: []` のまま SSH プッシュが通る）。

## 変更内容

### `fetch-tomachi-emojis.yml`

- **削除**: `peter-evans/create-pull-request` および `gh pr merge --auto` による PR 経由フロー
- **追加**: `Setup SSH for push` ステップ
  - `PUSH_DEPLOY_KEY` secret (Ed25519 秘密鍵) を `~/.ssh/deploy_ed25519` に書き込む
  - GitHub 公式 SSH ホスト鍵を固定値で `~/.ssh/known_hosts` に書き込む（ssh-keyscan による MITM リスクを回避）
  - SSH config で `deploy_ed25519` を github.com に紐付ける
  - `ssh -T git@github.com` で認証を事前確認
  - `git remote set-url` で SSH URL に変更して ruleset をバイパス
- **変更**: `permissions: contents: write, pull-requests: write` → `contents: read` に縮小
- **復元**: `persist-credentials: false`（SSH プッシュに GITHUB_TOKEN は不要なため）

### repository secret / deploy key（別途設定済み）

- Deploy Key (ID: 152339846): `Icons CI Deploy Key` — write 権限で登録済み
- Secret: `PUSH_DEPLOY_KEY` — Ed25519 秘密鍵を登録済み

## 動作フロー（修正後）

1. 毎時 cron 実行 → 絵文字取得 → README 生成
2. SSH 認証テストで deploy key を確認
3. `git push origin master` — ruleset をバイパスして直接プッシュ
4. 変更なし時は `git add -A && git commit || true` で空コミットをスキップ

## 判断記録

| 項目 | 内容 |
|---|---|
| 判断内容 | deploy key SSH プッシュで ruleset をバイパスする |
| 採用した根拠 | GitHub の仕様: write 権限 deploy key は ruleset を自動バイパス / scoop-bucket での実績 |
| 検討した代替案 | (1) PR + auto-merge (#1580)、(2) bypass_actors に GitHub Actions を追加、(3) PAT 使用 |
| 採用しなかった理由 | (1) 毎時 CI が必要になり遅延・複雑さが増す、(2) 管理者操作が必要、(3) トークン管理のオーバーヘッド |
| 前提・仮定 | deploy key の ruleset バイパスは GitHub の公式仕様であり、今後も継続される |